### PR TITLE
Add module-info.java, fixes #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: java
-jdk: oraclejdk8
+jdk: oraclejdk9

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/rzymek/opczip</url>
 
     <scm>
-        <url>${project.url}</url>
+        <url>https://github.com/rzymek/opczip</url>
     </scm>
 
     <licenses>
@@ -32,15 +32,15 @@
     </developers>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.0</version>
+            <version>5.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -52,13 +52,13 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.15.0</version>
+            <version>3.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.7.0-M1</version>
+            <version>5.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.23</version>
+            <version>1.29</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -78,16 +78,37 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <argLine>
+                        --add-opens com.github.rzymek.opczip/com.github.rzymek.opczip=ALL-UNNAMED
+                        --add-opens com.github.rzymek.opczip/com.github.rzymek.opczip.reader=ALL-UNNAMED
+                    </argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                      <id>default-compile</id>
+                      <configuration>
+                        <release>9</release>
+                      </configuration>
+                    </execution>
+                    <execution>
+                      <id>base-compile</id>
+                      <goals>
+                        <goal>compile</goal>
+                      </goals>
+                      <configuration>
+                          <excludes>
+                              <exclude>module-info.java</exclude>
+                          </excludes>
+                      </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -100,7 +121,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -113,7 +134,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -140,7 +161,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module com.github.rzymek.opczip {
+    exports com.github.rzymek.opczip;
+    exports com.github.rzymek.opczip.reader;
+    exports com.github.rzymek.opczip.reader.skipping;
+}

--- a/src/test/java/com/github/rzymek/opczip/reader/FileListTest.java
+++ b/src/test/java/com/github/rzymek/opczip/reader/FileListTest.java
@@ -9,9 +9,13 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -86,26 +90,16 @@ public class FileListTest implements ArgumentsProvider {
 
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
-        InputStream resource = FileListTest.class.getResourceAsStream(XLSX_DIR);
-        Scanner scanner = new Scanner(resource);
-        return StreamSupport.stream(
-                Spliterators.spliteratorUnknownSize(new Iterator<Arguments>() {
-                    @Override
-                    public boolean hasNext() {
-                        boolean hasNext = scanner.hasNext();
-                        if (!hasNext) {
-                            scanner.close();
-                        }
-                        return hasNext;
-                    }
-
-                    @Override
-                    public Arguments next() {
-                        return Arguments.of(scanner.nextLine());
-                    }
-                }, Spliterator.ORDERED),
-                false
-        );
+        try {
+            URI resource = FileListTest.class.getResource(XLSX_DIR).toURI();
+            Path path = Paths.get(resource);
+            return Files.list(path)
+                    .map(Path::getFileName)
+                    .map(Path::toString)
+                    .map(Arguments::of);
+        } catch (URISyntaxException | IOException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     @FunctionalInterface


### PR DESCRIPTION
I also took the liberty to do the following things, please tell me if I should revert some of them:

- Bump test dependency + plugin versions
- Set project.build.sourceEncoding to fix build warning
- Fix FileListTest when run as a module
- Bump Travis JDK version to oraclejdk9 (I assume that's the reason the build fails there right now)
- Set scm.url without property reference so it works on search.maven.org. You can see the current sad display here: https://search.maven.org/artifact/com.github.rzymek/opczip/1.2.0/jar

The `--add-opens` args for surefire are needed because JUnit reflectively calls the package private test methods, and that's not allowed when we are a module. An alternative would be to make every test class / method public, but that will probably just annoy future developers while providing little gain.